### PR TITLE
logique poussee plus loin + fix divers hors logique actions questmaster

### DIFF
--- a/app/controllers/questmaster/quests_controller.rb
+++ b/app/controllers/questmaster/quests_controller.rb
@@ -18,7 +18,7 @@ class Questmaster::QuestsController < ApplicationController
     @quest = Quest.new(quest_params)
     @quest.user = @user
     if @quest.save
-      redirect_to questmaster_quests_path(@quest)
+      redirect_to questmaster_quests_path
     else
       render :new
     end

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -1,5 +1,6 @@
 class Review < ApplicationRecord
   validates :rating, :content, presence: true
+  validates :content, length: { maximum: 200 }
 
   def blank_stars
     5 - rating.to_i

--- a/app/views/questmaster/quests/index.html.erb
+++ b/app/views/questmaster/quests/index.html.erb
@@ -37,21 +37,32 @@
     </main>
 
     <div class="links">
-      <% unless quest.progress == "Finished" %>
+      <% if quest.progress == "Finished" %>
+        <nav>
+            <% if quest.participations.any? { |p| p.user_review_id.nil? } %>
+              <%= link_to 'Make a global review',  new_questmaster_quest_review_path(quest), class: 'card-elements' %>
+            <% else %>
+              <a href="#">Global review already sent</a>
+            <% end %>
+        </nav>
+      <% elsif quest.progress == "Cancelled" %>
+        <nav>
+          <a href="#">No action available</a>
+        </nav>
+      <% else %>
         <nav>
             <%= link_to 'Edit',  edit_questmaster_quest_path(quest), class: 'card-elements' %>
         </nav>
         <nav>
             <%= link_to  'Cancel', questmaster_quest_path(quest, quest: { progress: "Cancelled"}), method: :patch, class: 'card-elements', data: { confirm: "Are you sure?" } %>
         </nav>
-        <nav>
-            <%= link_to 'Mark as over' ,  questmaster_quest_path(quest,quest , quest: { progress: "Finished"}), method: :patch, class: 'card-elements' %>
-        </nav>
-      <% end %>
-      <nav>
-          <%= link_to 'Review participations',  new_questmaster_quest_review_path(quest), class: 'card-elements' %>
-      </nav>
+        <% if quest.participations.any? %>
+          <nav>
+              <%= link_to 'Mark as over', questmaster_quest_path(quest, quest: { progress: "Finished"}), method: :patch, class: 'card-elements' %>
+          </nav>
+        <% end %>
 
+      <% end %>
     </div>
   </div>
   </div>

--- a/db/migrate/20190824103118_change_level_of_users.rb
+++ b/db/migrate/20190824103118_change_level_of_users.rb
@@ -1,0 +1,5 @@
+class ChangeLevelOfUsers < ActiveRecord::Migration[5.2]
+  def change
+    change_column :users, :level, 'integer USING CAST(level AS integer)'
+  end
+end

--- a/db/migrate/20190824104259_add_default_level_to_users.rb
+++ b/db/migrate/20190824104259_add_default_level_to_users.rb
@@ -1,0 +1,7 @@
+class AddDefaultLevelToUsers < ActiveRecord::Migration[5.2]
+  def change
+    change_column_default(:users, :level, from: nil, to: 1)
+  end
+end
+
+# From... To... = pour que ce soit réversible, sinon on ne peut pas rollback

--- a/db/migrate/20190824104844_change_content_typeof_reviews.rb
+++ b/db/migrate/20190824104844_change_content_typeof_reviews.rb
@@ -1,0 +1,5 @@
+class ChangeContentTypeofReviews < ActiveRecord::Migration[5.2]
+  def change
+    change_column :reviews, :content, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_24_081553) do
+ActiveRecord::Schema.define(version: 2019_08_24_104844) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -62,7 +62,7 @@ ActiveRecord::Schema.define(version: 2019_08_24_081553) do
 
   create_table "reviews", force: :cascade do |t|
     t.integer "rating"
-    t.string "content"
+    t.text "content"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
@@ -83,7 +83,7 @@ ActiveRecord::Schema.define(version: 2019_08_24_081553) do
     t.string "photo"
     t.string "entity_photo"
     t.integer "xp", default: 0
-    t.string "level"
+    t.integer "level", default: 1
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
Le questmaster ne peut désormais voir que ce qu'il est logique qu'il puisse faire (exemple: je ne peux pas review si la quête est annulée ou finie, je ne peux pas mark as done s'il n'y a eu aucun participant (car dans ce cas je dois cancel et non mark as done, etc.)

Migrations :
- Fix de valeur par défault et de type pour le level (user), qui était jusqu'à présent nil et string (>> 1 et integer)
- Modif type de content (review) : string >> text (+ limite dans modèle à 200 caractères)